### PR TITLE
Fixes Gatsby build error when running in a non-browser environment.

### DIFF
--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -55,9 +55,12 @@ class Landing extends React.Component<ISignupPageProps, { hovered: boolean }> {
     console.log(googleUser.getAuthResponse().id_token);
     const res = await signupOrLoginUser(googleUser.getAuthResponse().id_token);
     const userInfo = googleUser.profileObj;
-    sessionStorage.setItem("userInfo", userInfo.givenName);
-    sessionStorage.setItem("imgUrl", userInfo.imageUrl);
-    sessionStorage.setItem("email", userInfo.email);
+
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem("userInfo", userInfo.givenName);
+      sessionStorage.setItem("imgUrl", userInfo.imageUrl);
+      sessionStorage.setItem("email", userInfo.email);
+    }
     //window.imgUrl = userInfo.imageUrl;
     //window.email = userInfo.email;
     navigate("/home/");

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -116,9 +116,9 @@ class Profile extends React.Component<
   constructor(props) {
     super(props);
     this.state = {
-      username: sessionStorage.getItem("userInfo"),
-      imgURL: sessionStorage.getItem("imgUrl"),
-      email: sessionStorage.getItem("email"),
+      username: (typeof window !== 'undefined') ? sessionStorage.getItem("userInfo") : "",
+      imgURL: (typeof window !== 'undefined') ? sessionStorage.getItem("imgUrl"): "",
+      email: (typeof window !== 'undefined') ? sessionStorage.getItem("email"): "",
       isEditing: false,
       saved: [
         { plaintext: "test1", summarizedText: "test" },

--- a/client/src/pages/topbar.tsx
+++ b/client/src/pages/topbar.tsx
@@ -50,8 +50,8 @@ const profPic: React.CSSProperties = {
 };
 
 const TopBar = () => {
-  const [user] = React.useState(sessionStorage.getItem("userInfo"));
-  const [imgURL] = React.useState(sessionStorage.getItem("imgUrl"));
+  const [user] = React.useState((typeof window !== 'undefined') ? sessionStorage.getItem("userInfo") : null);
+  const [imgURL] = React.useState((typeof window !== 'undefined') ? sessionStorage.getItem("imgUrl"): null);
   return (
     <div style={topbar}>
       <div className="flex" style={{ display: "flex-row" }}>


### PR DESCRIPTION
Why: Running gatsby build locally or in prod fails because the sessionStorage variable is not available. This happens because the build command is run in a shell where the browser APIs are not available and hence causing and undefined sessionStorage variable.

Fix: Check if 'window' is defined before accessing sessionStorage